### PR TITLE
Modernize CV portfolio with minimalist design, dark mode & animations

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,13 +10,10 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@fortawesome/fontawesome-free": "^6.5.2",
     "@fortawesome/fontawesome-svg-core": "^6.5.2",
     "@fortawesome/free-brands-svg-icons": "^6.5.2",
     "@fortawesome/free-solid-svg-icons": "^6.5.2",
     "@fortawesome/react-fontawesome": "^0.2.2",
-    "bootstrap": "^5.3.3",
-    "fontawesome": "^5.6.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/src/hooks/useIntersectionObserver.ts
+++ b/src/hooks/useIntersectionObserver.ts
@@ -8,7 +8,7 @@ export function useIntersectionObserver<T extends HTMLElement = HTMLElement>(
 	useEffect(() => {
 		const el = ref.current;
 		if (!el) return;
-		const targets = el.querySelectorAll<HTMLElement>(".reveal");
+
 		const observer = new IntersectionObserver(
 			(entries) => {
 				entries.forEach((entry) => {
@@ -20,8 +20,22 @@ export function useIntersectionObserver<T extends HTMLElement = HTMLElement>(
 			},
 			{ threshold }
 		);
-		targets.forEach((t) => observer.observe(t));
-		return () => observer.disconnect();
+
+		const observeNew = () => {
+			el.querySelectorAll<HTMLElement>(".reveal:not(.visible)").forEach(
+				(t) => observer.observe(t)
+			);
+		};
+
+		observeNew();
+
+		const mutation = new MutationObserver(observeNew);
+		mutation.observe(el, { childList: true, subtree: true });
+
+		return () => {
+			observer.disconnect();
+			mutation.disconnect();
+		};
 	}, [threshold]);
 
 	return ref;

--- a/src/styles/experience.css
+++ b/src/styles/experience.css
@@ -10,7 +10,7 @@
 .timeline::before {
 	content: '';
 	position: absolute;
-	left: 9px;
+	left: 10px;
 	top: 8px;
 	bottom: 8px;
 	width: 2px;


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **New design system** — replaces cadetblue palette with a sophisticated neutral palette (`#0a0a0a` / `#fefefe` / `#6366f1` accent) backed by CSS custom properties; dark mode via `[data-theme="dark"]` on `<html>`, persisted to `localStorage` with `prefers-color-scheme` fallback
- **Glassmorphism header** — `backdrop-filter: blur(12px)` activates on scroll; 2px accent scroll-progress bar; moon/sun dark-mode toggle; underline-slide nav links; smooth mobile slide-down menu
- **Hero section** — full-viewport layout, typewriter role-cycling animation ("Full Stack Developer" → "React Specialist" → "UI Enthusiast"), subtle gradient background, outline + ghost CTA buttons, animated chevron scroll indicator
- **Experience timeline** — accordion replaced with vertical timeline (line + dot markers); smooth `max-height` expand/collapse transitions; dot scales + accent color on active item
- **Skills** — star ratings replaced with animated horizontal progress bars (animated via Intersection Observer + CSS `width` transition on `.visible`); pill-style filter buttons; MutationObserver in shared hook handles re-rendered cards after filter change
- **Portfolio** — 2-column grid; hover overlay reveals project description + link; image scales on hover
- **Contact** — floating label inputs using `focus-within` + `has-value` class pattern
- **Footer** — minimal: social icons (scale on hover) + copyright year; colored background removed
- **Bootstrap removed** entirely from imports and `package.json`; legacy `fontawesome` v5 dep also removed
- **Shared hook** `src/hooks/useIntersectionObserver.ts` — generic, used across Experience, Skill, Portfolio, Contact; includes `MutationObserver` to catch newly rendered elements after dynamic filter changes

## Test plan

- [ ] Light mode: verify all sections render correctly with neutral palette
- [ ] Dark mode: toggle via moon/sun button; reload page — preference persists
- [ ] Scroll to 50px: glassmorphism nav activates; progress bar fills as you scroll
- [ ] Hero: typewriter cycles through 3 roles; cursor blinks; gradient visible
- [ ] Experience: click each timeline entry to expand/collapse; dot turns accent on active
- [ ] Skills "All" → "Frontend" → "Backend" → "Tools" → "All": filter works; progress bars animate in on each filter change (MutationObserver fix)
- [ ] Portfolio: hover a card to see overlay + image scale
- [ ] Contact: focus an input — label floats up; submit redirects to WhatsApp
- [ ] Mobile (≤640px): hamburger opens smooth slide-down menu; 1-column portfolio grid
- [ ] `npm run build` — zero TypeScript errors ✓
- [ ] `npm run lint` — zero warnings ✓

https://claude.ai/code/session_018uQdFbyh1azuFu2DStrL4i
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_018uQdFbyh1azuFu2DStrL4i)_